### PR TITLE
v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dez80"
-version = "3.0.1"
+version = "4.0.0"
 description = "A Z80 instruction decoding and (dis)assembly library."
 repository = "https://github.com/rzumer/dez80"
 authors = ["Raphaël Zumer <rzumer@tebako.net>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "dez80"
 version = "3.0.1"
-description = "A Z80 disassembly library."
+description = "A Z80 instruction decoding and (dis)assembly library."
 repository = "https://github.com/rzumer/dez80"
 authors = ["Raphaël Zumer <rzumer@tebako.net>"]
 license = "MIT"
 edition = "2021"
 
 [dependencies]
-strum = "0.19"
-strum_macros = "0.19"
+strum = "0.26"
+strum_macros = "0.26"
 
 [dev-dependencies]
-criterion = "0.3"
-rayon = "1.4"
+criterion = "0.5"
+rayon = "1.8"
 
 [[bench]]
 name = "bench"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -11,7 +11,7 @@ const INSTRUCTION_STREAM: &[u8] = include_bytes!("../tests/allinstructions.bin")
 
 fn bench_instruction_from_bytes(c: &mut Criterion) {
     c.bench_function("Instruction::from_bytes", |b| {
-        b.iter(|| Instruction::decode_all(&mut INSTRUCTION_STREAM))
+        b.iter(|| Instruction::decode_all(&mut &INSTRUCTION_STREAM[..]))
     });
 }
 
@@ -24,7 +24,7 @@ fn bench_instruction_to_bytes(c: &mut Criterion) {
         b.iter(|| instructions.par_iter().flat_map(|i| i.to_bytes()).collect::<Vec<u8>>())
     }
 
-    let mut instructions = Instruction::decode_all(&mut INSTRUCTION_STREAM);
+    let mut instructions = Instruction::decode_all(&mut &INSTRUCTION_STREAM[..]);
     while instructions.len() < 1024 {
         instructions.append(&mut instructions.clone());
     }
@@ -43,7 +43,7 @@ fn bench_instruction_to_string(c: &mut Criterion) {
         b.iter(|| instructions.par_iter().map(|i| i.to_string()).collect::<Vec<String>>())
     }
 
-    let mut instructions = Instruction::decode_all(&mut INSTRUCTION_STREAM);
+    let mut instructions = Instruction::decode_all(&mut &INSTRUCTION_STREAM[..]);
     while instructions.len() < 1024 {
         instructions.append(&mut instructions.clone());
     }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate criterion;
 
-use criterion::{Bencher, Criterion, Fun};
+use criterion::{Bencher, Criterion};
 use dez80::Instruction;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
@@ -24,17 +24,14 @@ fn bench_instruction_to_bytes(c: &mut Criterion) {
         b.iter(|| instructions.par_iter().flat_map(|i| i.to_bytes()).collect::<Vec<u8>>())
     }
 
-    let sequential_operations = Fun::new("Sequential", bench_sequential);
-    let parallel_operations = Fun::new("Parallel", bench_parallel);
-
-    let funs = vec![sequential_operations, parallel_operations];
     let mut instructions = Instruction::decode_all(&mut INSTRUCTION_STREAM);
-
     while instructions.len() < 1024 {
         instructions.append(&mut instructions.clone());
     }
 
-    c.bench_functions("Instruction::to_bytes", funs, instructions);
+    let mut bench_group = c.benchmark_group("Instruction::to_bytes");
+    bench_group.bench_with_input("Sequential", &instructions, bench_sequential);
+    bench_group.bench_with_input("Parallel", &instructions, bench_parallel);
 }
 
 fn bench_instruction_to_string(c: &mut Criterion) {
@@ -46,17 +43,14 @@ fn bench_instruction_to_string(c: &mut Criterion) {
         b.iter(|| instructions.par_iter().map(|i| i.to_string()).collect::<Vec<String>>())
     }
 
-    let sequential_operations = Fun::new("Sequential", bench_sequential);
-    let parallel_operations = Fun::new("Parallel", bench_parallel);
-
-    let funs = vec![sequential_operations, parallel_operations];
     let mut instructions = Instruction::decode_all(&mut INSTRUCTION_STREAM);
-
     while instructions.len() < 1024 {
         instructions.append(&mut instructions.clone());
     }
 
-    c.bench_functions("Instruction::to_string", funs, instructions);
+    let mut bench_group = c.benchmark_group("Instruction::to_string");
+    bench_group.bench_with_input("Sequential", &instructions, bench_sequential);
+    bench_group.bench_with_input("Parallel", &instructions, bench_parallel);
 }
 
 criterion_group!(

--- a/bin/Cargo.lock
+++ b/bin/Cargo.lock
@@ -3,106 +3,114 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstyle"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "utf8parse",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
+name = "anstyle-query"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "anstyle-wincon"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
+name = "clap_builder"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
- "cfg-if",
- "crossbeam-utils",
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "once_cell",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "dez80"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "strum",
  "strum_macros",
@@ -119,136 +127,90 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.132"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
+name = "rustversion"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.19.5"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a286a7e3b5720b9a477b23253bc50debac207c8d21505f8e70b36792f11b5"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 
 [[package]]
 name = "strum_macros"
-version = "0.19.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,56 +218,79 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-targets",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-targets"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dez80_cli"
 version = "1.0.2"
 description = "A Z80 disassembler interface based on the DeZ80 library."
-repository = "https://github.com/rzumer/rz80"
+repository = "https://github.com/rzumer/dez80"
 authors = ["Raphaël Zumer <rzumer@tebako.net>"]
 license = "MIT"
 edition = "2018"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -5,7 +5,7 @@ description = "A Z80 disassembler interface based on the DeZ80 library."
 repository = "https://github.com/rzumer/dez80"
 authors = ["Raphaël Zumer <rzumer@tebako.net>"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["rayon"]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 default = ["rayon"]
 
 [dependencies]
-clap = "2.33"
-rayon = { version = "1.4", optional = true }
+clap = { version = "4.4", features = ["cargo"] }
+rayon = { version = "1.8", optional = true }
 dez80 = { path = "../" }

--- a/bin/rustfmt.toml
+++ b/bin/rustfmt.toml
@@ -1,3 +1,3 @@
-merge_imports = true
+imports_granularity = "Crate"
 use_field_init_shorthand = true
 use_small_heuristics = "Max"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -38,7 +38,7 @@ use crate::instruction::*;
 /// Represents an instruction decoder that maintains a state.
 /// Its main use case is to decode instructions progressively
 /// byte by byte, when a data source cannot implement `Read`.
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct InstructionDecoder {
     received_bytes: Vec<u8>,
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -7,7 +7,7 @@
 //! use dez80::InstructionDecoder;
 //!
 //! // Initialize a stateful instruction decoder.
-//! let mut decoder = InstructionDecoder::new();
+//! let mut decoder = InstructionDecoder::default();
 //!
 //! // Decode a single byte with the decoder.
 //! decoder.push_byte(0x00); // NOP
@@ -44,10 +44,6 @@ pub struct InstructionDecoder {
 }
 
 impl InstructionDecoder {
-    pub fn new() -> Self {
-        InstructionDecoder { received_bytes: Vec::new() }
-    }
-
     /// Attempts to decode one instruction from the decoder's source.
     /// If there is not enough data to complete the decoding process,
     /// an `Err<DecodingState>` is returned, which describes the state
@@ -86,7 +82,7 @@ mod tests {
     #[test]
     fn decode_single_byte_with_decoder() {
         let instruction_byte = 0x00;
-        let mut decoder = InstructionDecoder::new();
+        let mut decoder = InstructionDecoder::default();
         decoder.push_byte(instruction_byte);
         let result = decoder.try_decode();
         assert!(result.is_ok());
@@ -97,7 +93,7 @@ mod tests {
     #[test]
     fn decode_multiple_bytes_with_decoder() {
         let instruction_bytes = &[0x01, 0x02, 0x03];
-        let mut decoder = InstructionDecoder::new();
+        let mut decoder = InstructionDecoder::default();
         decoder.push_byte(instruction_bytes[0]); // LD BC, **
         assert!(decoder.try_decode().is_err());
         decoder.push_byte(instruction_bytes[1]); // LD BC, 0x**02
@@ -112,7 +108,7 @@ mod tests {
     #[test]
     fn decode_slice_with_decoder() {
         let instruction_bytes = &[0x01, 0x33, 0x22];
-        let mut decoder = InstructionDecoder::new();
+        let mut decoder = InstructionDecoder::default();
         decoder.push_slice(instruction_bytes);
         let result = decoder.try_decode();
         assert!(result.is_ok());
@@ -123,7 +119,7 @@ mod tests {
     #[test]
     fn decode_two_instruction_slice_with_decoder() {
         let instruction_bytes = &[0x06, 0x11, 0x00];
-        let mut decoder = InstructionDecoder::new();
+        let mut decoder = InstructionDecoder::default();
 
         // LD B, *
         decoder.push_slice(instruction_bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,9 @@
 extern crate strum;
 extern crate strum_macros;
 
-pub mod decoder;
+mod decoder;
 pub mod instruction;
 pub mod register;
 
 pub use decoder::InstructionDecoder;
-pub use instruction::Instruction;
-pub use register::*;
+pub use instruction::{DecodingState, Instruction};


### PR DESCRIPTION
* Update dependencies and their usage
* Clean up some minor warnings and comments
* Add some interfaces and re-exports
* Remove some interfaces and re-exports
* Distinguish displacement operands from non-displacement operands in `DecodingState`

Bonus: hopefully gets rid of the spooky security warning on GitHub.